### PR TITLE
Add experiment logging and plotting

### DIFF
--- a/tp3-algoritmos-busqueda/code/main.py
+++ b/tp3-algoritmos-busqueda/code/main.py
@@ -1,4 +1,5 @@
 # main.py
+import csv
 import gymnasium as gym
 import numpy as np
 
@@ -37,11 +38,11 @@ def generate_large_custom_map(size=8, p_frozen=0.9, seed=None):
     return desc
 
 if __name__ == "__main__":
-    # Mapa grande determinista
+    # Mapa determinista grande
     desc = generate_large_custom_map(size=100, p_frozen=0.92, seed=123)
 
-    env = gym.make('FrozenLake-v1', desc=desc, is_slippery=False, render_mode='human').env
-    env = gym.wrappers.TimeLimit(env, max_episode_steps=2000)  # por si el plan es largo
+    env = gym.make("FrozenLake-v1", desc=desc, is_slippery=False).env
+    env = gym.wrappers.TimeLimit(env, max_episode_steps=2000)
 
     runner = EpisodeRunner(env)
     agents = [
@@ -54,7 +55,34 @@ if __name__ == "__main__":
         ("A* (Manhattan)", AStarAgent()),
     ]
 
+    EPISODES = 30
+    results = []
+
     for name, agent in agents:
-        print(f"\n=== {name} ===")
-        reward, done, truncated = runner.run(agent, verbose=True)
-        print(f"Resultado {name} -> reward={reward}, done={done}, truncated={truncated}")
+        for episode in range(1, EPISODES + 1):
+            reward, done, truncated, steps = runner.run(agent, verbose=False)
+            results.append(
+                {
+                    "algorithm": name,
+                    "episode": episode,
+                    "reward": reward,
+                    "done": done,
+                    "truncated": truncated,
+                    "steps": steps,
+                }
+            )
+
+    with open("results.csv", "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["algorithm", "episode", "reward", "done", "truncated", "steps"]
+        )
+        writer.writeheader()
+        writer.writerows(results)
+
+    # Mostrar un resumen simple en consola
+    for name, _ in agents:
+        alg_results = [r for r in results if r["algorithm"] == name]
+        wins = [r for r in alg_results if r["done"]]
+        win_rate = len(wins) / EPISODES
+        avg_steps = sum(r["steps"] for r in wins) / len(wins) if wins else float("nan")
+        print(f"{name}: tasa de victoria {win_rate:.2%}, pasos promedio {avg_steps:.1f}")

--- a/tp3-algoritmos-busqueda/code/plot_results.py
+++ b/tp3-algoritmos-busqueda/code/plot_results.py
@@ -1,0 +1,54 @@
+import csv
+import math
+import matplotlib.pyplot as plt
+
+
+def load_results(path="results.csv"):
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        data = []
+        for row in reader:
+            data.append(
+                {
+                    "algorithm": row["algorithm"],
+                    "episode": int(row["episode"]),
+                    "reward": float(row["reward"]),
+                    "done": row["done"] == "True",
+                    "truncated": row["truncated"] == "True",
+                    "steps": int(row["steps"]),
+                }
+            )
+        return data
+
+
+def main():
+    data = load_results()
+    algorithms = sorted({d["algorithm"] for d in data})
+
+    wins = []
+    avg_steps = []
+    for alg in algorithms:
+        alg_runs = [d for d in data if d["algorithm"] == alg]
+        win_runs = [d for d in alg_runs if d["done"]]
+        wins.append(len(win_runs))
+        avg_steps.append(
+            sum(r["steps"] for r in win_runs) / len(win_runs) if win_runs else math.nan
+        )
+
+    plt.figure()
+    plt.bar(algorithms, wins)
+    plt.ylabel("Victorias en 30 episodios")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig("wins.png")
+
+    plt.figure()
+    plt.bar(algorithms, avg_steps)
+    plt.ylabel("Pasos promedio (solo victorias)")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig("avg_steps.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/tp3-algoritmos-busqueda/code/runner.py
+++ b/tp3-algoritmos-busqueda/code/runner.py
@@ -24,14 +24,20 @@ class EpisodeRunner:
             step += 1
 
             if verbose:
-                print(f"Paso {step} | Accion: {action} | Nuevo estado: {next_state} | Recompensa: {reward}")
+                print(
+                    f"Paso {step} | Accion: {action} | Nuevo estado: {next_state} | Recompensa: {reward}"
+                )
                 if reward == 1.0:
                     print(f"¿Gano? (encontro el objetivo): {done}")
                 else:
                     print(f"¿Gano? (encontro el objetivo): False")
                     print(f"¿Perdio? (se cayo): {done}")
-                    print(f"¿Freno? (alcanzo el maximo de pasos posible): {truncated}\n")
+                    print(
+                        f"¿Freno? (alcanzo el maximo de pasos posible): {truncated}\n"
+                    )
 
             state = next_state
 
-        return reward, done, truncated
+        # Devolvemos también el número de pasos para facilitar el registro de
+        # estadísticas en experimentos repetidos.
+        return reward, done, truncated, step


### PR DESCRIPTION
## Summary
- Run every search agent 30 times and save episode outcomes to `results.csv`
- Extend runner to report step counts for statistics
- Provide `plot_results.py` to visualize wins and step efficiency

## Testing
- `pytest -q`
- `python tp3-algoritmos-busqueda/code/main.py` (fails: No module named 'gymnasium')
- `python tp3-algoritmos-busqueda/code/plot_results.py` (fails: No module named 'matplotlib')


------
https://chatgpt.com/codex/tasks/task_e_68b5f160e4e48327ae805275b5b17bb4